### PR TITLE
Added information about online participation in workshop

### DIFF
--- a/workshop-2023/index.html
+++ b/workshop-2023/index.html
@@ -86,6 +86,7 @@
 		The workshop  will start on Monday,
 		September 11 at 13:00 (1pm) and will feature talks and coding sessions.
 		It will be preceded by a deal.II crash course starting at 9:00 (9am) on Monday morning.
+		The talks and deal.II crash course can also be attended <u>online</u>, but participation in the coding session is only in person.
 		The social program has a conference dinner on Tuesday evening
 		and a small excursion to Herrenhausen Gardens on Thursday. </br></br>
 		
@@ -104,6 +105,7 @@
 		  <li> Hendrik Fischer, Leibniz University Hannover
 		  <li> Leon Kolditz, Leibniz University Hannover
 		  <li> Lukas Dreyer, Leibniz University Hannover / DLR Braunschweig
+		  <li> Tobias Knoke, Leibniz University Hannover
 		</ul>
 	      </p>
 	      
@@ -120,7 +122,7 @@
 
 	      <p>
 		September 11-15, 2023 at the Leibniz University Hannover in Germany. 
-		The workshop will be held <!-- TODO: add the exact room number and the room location inside the university -->
+		The workshop will be held in <a href="https://info.cafm.uni-hannover.de/room/1101.001.F142">room F142</a>
 		in the main building of Leibniz University Hannover:
 	      </p>
 


### PR DESCRIPTION
Minor changes to the workshop 2023 website.

We discussed internally how online participation in the workshop could be realized. 
We have all the necessary technological equipment to stream the presentations and the deal.II crash course to the online audience.
Allowing presentations from the online audience could be more complicated since one needs to ensure that the presenter has a good internet connection. From experience, there have frequently been some technological difficulties.
Therefore we only want to allow online presentations from the deal.II core developers and would ask you for a video recording of your talk if you're going to present, to avoid any technological issues.