### PR TITLE
Correct the link to the performance test suite.

### DIFF
--- a/header.include
+++ b/header.include
@@ -79,7 +79,7 @@
                 <li><a href="/developer/doxygen/deal.II/index.html">Manual</a></li>
                 <li><hr></li>
                 <li><a href="https://cdash.dealii.org/index.php?project=deal.II">Tests</a></li>
-                <li><a href="https://www.math.clemson.edu/~heister/bench/">Performance tests</a></li>
+                <li><a href="https://dealii.org/performance_tests/graphs/">Performance tests</a></li>
                 <li><a href="/developer/developers/testsuite.html">Testing info</a></li>
               </ul>
             </li>

--- a/pdeschool-2019/header.include
+++ b/pdeschool-2019/header.include
@@ -79,7 +79,7 @@
                 <li><a href="/developer/doxygen/deal.II/index.html">Manual</a></li>
                 <li><hr></li>
                 <li><a href="http://cdash.dealii.org/index.php?project=deal.II">Tests</a></li>
-                <li><a href="http://www.math.clemson.edu/~heister/bench/">Performance tests</a></li>
+                <li><a href="https://dealii.org/performance_tests/graphs/">Performance tests</a></li>
                 <li><a href="/developer/developers/testsuite.html">Testing info</a></li>
               </ul>
             </li>

--- a/workshop-2015/header.include
+++ b/workshop-2015/header.include
@@ -76,7 +76,7 @@
                 <li><a href="/developer/doxygen/deal.II/index.html">Manual</a></li>
                 <li><hr></li>
                 <li><a href="http://cdash.dealii.org/index.php?project=deal.II">Tests</a></li>
-                <li><a href="http://www.math.clemson.edu/~heister/bench/">Performance tests</a></li>
+                <li><a href="https://dealii.org/performance_tests/graphs/">Performance tests</a></li>
                 <li><a href="/developer/developers/testsuite.html">Testing info</a></li>
               </ul>
             </li>

--- a/workshop-2019/header.include
+++ b/workshop-2019/header.include
@@ -79,7 +79,7 @@
                 <li><a href="/developer/doxygen/deal.II/index.html">Manual</a></li>
                 <li><hr></li>
                 <li><a href="http://cdash.dealii.org/index.php?project=deal.II">Tests</a></li>
-                <li><a href="http://www.math.clemson.edu/~heister/bench/">Performance tests</a></li>
+                <li><a href="https://dealii.org/performance_tests/graphs/">Performance tests</a></li>
                 <li><a href="/developer/developers/testsuite.html">Testing info</a></li>
               </ul>
             </li>

--- a/workshop-2020/header.include
+++ b/workshop-2020/header.include
@@ -79,7 +79,7 @@
                 <li><a href="/developer/doxygen/deal.II/index.html">Manual</a></li>
                 <li><hr></li>
                 <li><a href="http://cdash.dealii.org/index.php?project=deal.II">Tests</a></li>
-                <li><a href="http://www.math.clemson.edu/~heister/bench/">Performance tests</a></li>
+                <li><a href="https://dealii.org/performance_tests/graphs/">Performance tests</a></li>
                 <li><a href="/developer/developers/testsuite.html">Testing info</a></li>
               </ul>
             </li>

--- a/workshop-2021/header.include
+++ b/workshop-2021/header.include
@@ -79,7 +79,7 @@
                 <li><a href="/developer/doxygen/deal.II/index.html">Manual</a></li>
                 <li><hr></li>
                 <li><a href="http://cdash.dealii.org/index.php?project=deal.II">Tests</a></li>
-                <li><a href="http://www.math.clemson.edu/~heister/bench/">Performance tests</a></li>
+                <li><a href="https://dealii.org/performance_tests/graphs/">Performance tests</a></li>
                 <li><a href="/developer/developers/testsuite.html">Testing info</a></li>
               </ul>
             </li>

--- a/workshop-2023/header.include
+++ b/workshop-2023/header.include
@@ -79,7 +79,7 @@
                 <li><a href="/developer/doxygen/deal.II/index.html">Manual</a></li>
                 <li><hr></li>
                 <li><a href="http://cdash.dealii.org/index.php?project=deal.II">Tests</a></li>
-                <li><a href="http://www.math.clemson.edu/~heister/bench/">Performance tests</a></li>
+                <li><a href="https://dealii.org/performance_tests/graphs/">Performance tests</a></li>
                 <li><a href="/developer/developers/testsuite.html">Testing info</a></li>
               </ul>
             </li>


### PR DESCRIPTION
https://github.com/dealii/dealii/issues/8852 made me realize that we don't link to the performance tests page. This patch fixes this.