### PR TITLE
Add Thomas Wick as an author.

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -321,6 +321,7 @@
 <li> Weygand, Daniel 
 <li> White, Joshua 
 <li> Wichrowski, Michał 
+<li> Wick, Thomas
 <li> Wik, Niklas 
 <li> Witte, Julius 
 <li> Wollner, Winnifried 


### PR DESCRIPTION
Thomas conveyed to me a funny story how it came that his name doesn't show up in the author list in svn/git. He wanted to commit to the svn repository, but just the day he wanted to, the svn server was down. It was at a workshop where I was too, so I said 'just send the patch to me, and I'll commit it for you', and that's how we did it. So his patch is under my name in the svn repository, and so his name was never picked up when we created the author list.

@tommeswick FYI